### PR TITLE
Revamp planner layout and styling

### DIFF
--- a/APP_OVERVIEW.md
+++ b/APP_OVERVIEW.md
@@ -1,0 +1,51 @@
+# Visión general
+
+Este documento resume el funcionamiento de la aplicación de planificación WRO y describe la estructura de archivos relevantes del proyecto.
+
+## Funcionamiento general
+
+- La interfaz se monta con `src/main.jsx`, que carga estilos globales (`src/index.css`) y renderiza el componente principal `App`.
+- `src/App.jsx` sirve como contenedor y delega toda la lógica a `src/wroplayback_planner_fix_snap_15.jsx`.
+- El componente `WROPlaybackPlanner` gestiona estado, renderizado y eventos del planificador usando un lienzo HTML5 y paneles laterales React.
+- La visualización usa imágenes de tapetes WRO 2025 (`src/assets/*.jpg`) combinadas con una cuadrícula configurable y el esquema de colores definido en `src/index.css`.
+
+## Características principales
+
+### Configuración del entorno de trabajo
+- Selección de tapetes predefinidos (Junior, Elementary, Double Tennis) o subida de un fondo personalizado.
+- Control de opacidad del tapete, parámetros de cuadrícula (tamaño de celda, offsets, densidad) y unidad de medida intercambiable cm/mm.
+- Personalización del robot (dimensiones, color, imagen) y ajuste de la pose inicial directamente desde el panel de opciones.
+
+### Planificación de trayectorias
+- Dibujo en canvas con soporte de snapping a cuadrícula o a incrementos de 15 grados (corrección incluida para asegurar que el punto trazado respeta el ángulo).
+- Modo de dibujo en reversa para registrar trayectos desde el final hacia el inicio.
+- Alternancia de referencia entre centro de las ruedas y punta del robot al generar movimientos.
+- Edición posterior de nodos con arrastre y actualización visual del recorrido.
+
+### Gestión de secciones y acciones
+- Creación de múltiples secciones de misión, cada una con su color, visibilidad y nombre editable.
+- Conversión automática de trazos en acciones discretas (`move` y `rotate`) que pueden reorganizarse mediante drag and drop.
+- Reproducción individual de secciones o del conjunto completo en sentido normal o inverso, con menú rápido activado por pulsación prolongada.
+
+### Herramientas complementarias
+- Regla interactiva para medir distancias entre puntos del canvas.
+- Ajuste manual del origen de coordenadas directamente sobre el tapete.
+- Controles de zoom con límites definidos y restablecimiento rápido.
+- Exportación de la misión a JSON descargable e importación para restaurar sesiones previas.
+
+## Estructura de archivos
+
+- `package.json` y `package-lock.json` definen dependencias y scripts (React 19, Vite, Tailwind, ESLint).
+- `vite.config.js`, `postcss.config.cjs`, `tailwind.config.cjs` y `eslint.config.js` configuran la toolchain de build, estilos y linting.
+- `index.html` establece la plantilla base y carga el bundle de React.
+- `src/main.jsx` monta la aplicación y aplica los estilos globales.
+- `src/App.jsx` encapsula el componente del planificador.
+- `src/index.css` aporta las utilidades Tailwind y los estilos detallados de paneles, toolbar y canvas.
+- `src/wroplayback_planner_fix_snap_15.jsx` contiene la lógica completa del planificador: estados, renders, snapping corregido, reproducción y paneles auxiliares.
+- `src/assets/` alberga las imágenes de tapetes de juego y el icono SVG del template.
+- `public/vite.svg` se usa como favicon por defecto en `index.html`.
+
+## Consideraciones adicionales
+
+- No se documentan módulos dentro de `node_modules`, porque pertenecen al ecosistema de dependencias externas.
+- Los estilos originales del template (`src/App.css`, `src/assets/react.svg`) permanecen en el proyecto pero no participan en la vista principal actual.

--- a/build_app/src/index.css
+++ b/build_app/src/index.css
@@ -96,6 +96,56 @@ body {
   backdrop-filter: blur(14px);
 }
 
+.toolbar-reverse-btn {
+  flex: 1 1 100%;
+  justify-content: space-between;
+  padding: 0.65rem 1rem;
+  background: linear-gradient(135deg, #e2e8f0, #cbd5f5);
+  color: #1f2937;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.toolbar-reverse-btn:hover {
+  background: linear-gradient(135deg, #cbd5f5, #94a3b8);
+  color: #0f172a;
+}
+
+.toolbar-reverse-btn--active {
+  background: linear-gradient(135deg, #fb923c, #ef4444);
+  color: #ffffff;
+  border: none;
+  box-shadow: 0 16px 32px rgba(239, 68, 68, 0.35);
+}
+
+.toolbar-reverse-btn--active:hover {
+  background: linear-gradient(135deg, #f97316, #dc2626);
+}
+
+.toolbar-reverse-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.toolbar-reverse-state {
+  font-weight: 700;
+  font-size: 0.9rem;
+}
+
+.toolbar-reverse-chip {
+  font-size: 0.7rem;
+  font-weight: 600;
+  padding: 0.2rem 0.55rem;
+  border-radius: 9999px;
+  background: rgba(15, 23, 42, 0.12);
+  color: #1f2937;
+}
+
+.toolbar-reverse-btn--active .toolbar-reverse-chip {
+  background: rgba(255, 255, 255, 0.24);
+  color: #ffffff;
+}
+
 .toolbar-menu-backdrop {
   position: fixed;
   inset: 0;

--- a/build_app/src/index.css
+++ b/build_app/src/index.css
@@ -96,6 +96,85 @@ body {
   backdrop-filter: blur(14px);
 }
 
+.toolbar-menu-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 5;
+  cursor: default;
+}
+
+.toolbar-longpress-menu {
+  position: fixed;
+  z-index: 10;
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  min-width: 9.5rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.92);
+  box-shadow: 0 22px 48px rgba(15, 23, 42, 0.28);
+  transform: translateY(-50%);
+}
+
+.toolbar-longpress-menu::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: -7px;
+  width: 12px;
+  height: 12px;
+  background: inherit;
+  transform: translateY(-50%) rotate(45deg);
+  border-radius: 3px;
+}
+
+.toolbar-longpress-label {
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.toolbar-menu-btn {
+  border: none;
+  border-radius: 0.6rem;
+  padding: 0.45rem 0.65rem;
+  font-size: 0.82rem;
+  font-weight: 600;
+  color: #ffffff;
+  cursor: pointer;
+  transition: transform 0.16s ease, background 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  justify-content: center;
+}
+
+.toolbar-menu-btn:hover {
+  transform: translateY(-1px);
+}
+
+.toolbar-menu-btn:active {
+  transform: translateY(0);
+}
+
+.toolbar-menu-btn--forward {
+  background: linear-gradient(135deg, #38bdf8, #2563eb);
+}
+
+.toolbar-menu-btn--forward:hover {
+  background: linear-gradient(135deg, #0ea5e9, #1d4ed8);
+}
+
+.toolbar-menu-btn--reverse {
+  background: linear-gradient(135deg, #f97316, #ef4444);
+}
+
+.toolbar-menu-btn--reverse:hover {
+  background: linear-gradient(135deg, #ea580c, #dc2626);
+}
+
 .toolbar-divider {
   height: 2rem;
   width: 1px;

--- a/build_app/src/index.css
+++ b/build_app/src/index.css
@@ -61,19 +61,90 @@ body {
   border-radius: 22px;
   box-shadow: 0 22px 45px rgba(79, 70, 229, 0.12);
   padding: 24px;
-  overflow: hidden;
   min-height: 460px;
   display: flex;
+  flex-direction: column;
+  gap: 1rem;
   align-items: stretch;
-  justify-content: center;
+  justify-content: flex-start;
   border: 1px solid rgba(79, 70, 229, 0.08);
 }
 
-/* Forzar que el canvas ocupe el 100% del ancho de la card y mantener el comportamiento de resize que hace tu script */
-.canvas-card canvas {
+/* Área del canvas con scroll y sombreado suave */
+.canvas-board {
+  position: relative;
+  flex: 1 1 auto;
   width: 100%;
-  height: auto;
+  overflow: auto;
+  border-radius: 18px;
+  background: linear-gradient(160deg, rgba(255,255,255,0.82), rgba(226,232,240,0.68));
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  padding: 0.75rem;
+}
+
+.canvas-board::-webkit-scrollbar {
+  width: 12px;
+  height: 12px;
+}
+
+.canvas-board::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.4);
+  border-radius: 999px;
+}
+
+.canvas-board::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.canvas-card canvas {
   display: block;
+  max-width: none;
+  border-radius: 14px;
+}
+
+.canvas-surface {
+  box-shadow: 0 22px 45px rgba(148, 163, 184, 0.2);
+  background-color: rgba(15, 23, 42, 0.04);
+}
+
+.canvas-legend {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  padding-right: 0.5rem;
+}
+
+.canvas-legend__item {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: rgba(255, 255, 255, 0.92);
+  border-radius: 999px;
+  padding: 0.35rem 0.9rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #475569;
+  box-shadow: 0 14px 28px rgba(148, 163, 184, 0.2);
+}
+
+.canvas-legend__swatch {
+  width: 32px;
+  height: 6px;
+  border-radius: 999px;
+  background: #0ea5e9;
+  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.6);
+}
+
+.canvas-legend__swatch--center {
+  background: linear-gradient(135deg, #0ea5e9, #6366f1);
+}
+
+.canvas-legend__swatch--tip {
+  background-image: repeating-linear-gradient(90deg, rgba(249, 115, 22, 0.9), rgba(249, 115, 22, 0.9) 8px, rgba(249, 115, 22, 0.15) 8px, rgba(249, 115, 22, 0.15) 16px);
+  border: 1px solid rgba(249, 115, 22, 0.55);
 }
 
 /* Ajustes menores visibilidad/espaciado para la lista de secciones */
@@ -144,6 +215,119 @@ body {
 .toolbar-reverse-btn--active .toolbar-reverse-chip {
   background: rgba(255, 255, 255, 0.24);
   color: #ffffff;
+}
+
+.toolbar-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.15rem 0.35rem;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6);
+}
+
+.toolbar-group__label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  color: #475569;
+}
+
+.toolbar-group--measure {
+  flex: 0 1 220px;
+}
+
+.toolbar-segmented {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.2rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.08);
+}
+
+.toolbar-segmented__btn {
+  border: none;
+  border-radius: 999px;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #0f172a;
+  background: transparent;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.toolbar-segmented__btn:hover {
+  background: rgba(96, 165, 250, 0.2);
+}
+
+.toolbar-segmented__btn--active {
+  background: linear-gradient(135deg, #6366f1, #22d3ee);
+  color: #ffffff;
+  box-shadow: 0 12px 28px rgba(79, 70, 229, 0.35);
+}
+
+.toolbar-group--zoom {
+  flex: 0 1 200px;
+}
+
+.toolbar-zoom-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  background: rgba(148, 163, 184, 0.2);
+  border-radius: 999px;
+  padding: 0.3rem 0.6rem;
+}
+
+.toolbar-zoom-btn {
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.95);
+  color: #1e293b;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.15);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.toolbar-zoom-btn:hover {
+  background: #e2e8f0;
+}
+
+.toolbar-zoom-value {
+  min-width: 52px;
+  text-align: center;
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #1e293b;
+}
+
+.toolbar-zoom-reset {
+  border: none;
+  background: transparent;
+  font-size: 0.7rem;
+  font-weight: 600;
+  color: #2563eb;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.toolbar-zoom-reset:hover {
+  background: rgba(59, 130, 246, 0.12);
+  color: #1d4ed8;
 }
 
 .playback-menu {
@@ -392,6 +576,26 @@ body {
   border-radius: 0.9rem;
   background: rgba(255, 255, 255, 0.95);
   border: 1px solid rgba(226, 232, 240, 0.7);
+}
+
+.section-card__field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.section-card__meta {
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.section-card__meta--center {
+  color: #0f172a;
+}
+
+.section-card__meta--tip {
+  color: #f97316;
 }
 
 .section-scroll {

--- a/build_app/src/index.css
+++ b/build_app/src/index.css
@@ -294,6 +294,277 @@ body {
   gap: 1rem;
 }
 
+.options-drawer__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+
+.options-drawer__title {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 700;
+  color: #1e293b;
+}
+
+.options-drawer__subtitle {
+  margin: 0.4rem 0 0;
+  font-size: 0.85rem;
+  color: #64748b;
+  line-height: 1.4;
+}
+
+.options-close-btn {
+  border: none;
+  background: rgba(226, 232, 240, 0.75);
+  color: #0f172a;
+  padding: 0.45rem 0.85rem;
+  border-radius: 0.75rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.1);
+}
+
+.options-close-btn:hover {
+  background: rgba(148, 163, 184, 0.65);
+  transform: translateY(-1px);
+}
+
+.options-drawer__intro {
+  font-size: 0.85rem;
+  color: #475569;
+  line-height: 1.5;
+  margin-bottom: 1.25rem;
+  background: rgba(99, 102, 241, 0.08);
+  border: 1px solid rgba(99, 102, 241, 0.15);
+  padding: 0.75rem 0.9rem;
+  border-radius: 0.9rem;
+}
+
+.options-drawer__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.option-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.option-section__header {
+  margin-bottom: 0.75rem;
+}
+
+.option-section__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+  color: #1e293b;
+}
+
+.option-section__subtitle {
+  margin: 0.4rem 0 0;
+  font-size: 0.8rem;
+  color: #64748b;
+  line-height: 1.45;
+}
+
+.option-card {
+  background: linear-gradient(150deg, rgba(248, 250, 252, 0.95) 0%, rgba(224, 231, 255, 0.9) 100%);
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  padding: 1rem;
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.14);
+}
+
+.option-card__grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 540px) {
+  .option-card__grid--auto {
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  }
+
+  .option-card__grid--two {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .option-card__grid--three {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.option-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  font-size: 0.9rem;
+  color: #1e293b;
+}
+
+.option-field__label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #475569;
+}
+
+.option-field__hint {
+  font-size: 0.75rem;
+  color: #64748b;
+  line-height: 1.35;
+}
+
+.option-field__controls {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.option-field__controls--single {
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.option-field__controls input[type="range"] {
+  flex: 1;
+  accent-color: #6366f1;
+}
+
+.option-field__value {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #4338ca;
+  min-width: 3.5rem;
+  text-align: right;
+  margin-left: auto;
+}
+
+.option-field__control {
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 0.85rem;
+  padding: 0.55rem 0.75rem;
+  font-size: 0.92rem;
+  color: #0f172a;
+  background: #ffffff;
+  box-shadow: 0 12px 22px rgba(15, 23, 42, 0.08);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.option-field__control:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
+}
+
+.option-field__control--color {
+  padding: 0.2rem;
+  height: 2.5rem;
+}
+
+.option-field--file .option-upload {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.55rem 0.95rem;
+  border-radius: 0.85rem;
+  background: rgba(59, 130, 246, 0.1);
+  color: #1d4ed8;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px dashed rgba(59, 130, 246, 0.4);
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.option-field--file .option-upload:hover {
+  background: rgba(59, 130, 246, 0.16);
+  transform: translateY(-1px);
+}
+
+.option-upload input[type="file"] {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.option-upload__text {
+  pointer-events: none;
+}
+
+.option-chip-button {
+  border: none;
+  background: linear-gradient(135deg, rgba(224, 231, 255, 0.9) 0%, rgba(129, 140, 248, 0.9) 100%);
+  color: #1e1b4b;
+  padding: 0.55rem 1rem;
+  border-radius: 999px;
+  font-weight: 600;
+  cursor: pointer;
+  box-shadow: 0 12px 24px rgba(99, 102, 241, 0.25);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.option-chip-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 32px rgba(79, 70, 229, 0.25);
+}
+
+.option-action-button {
+  border: none;
+  background: linear-gradient(135deg, #6366f1, #8b5cf6);
+  color: #ffffff;
+  padding: 0.6rem 1rem;
+  border-radius: 0.9rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  box-shadow: 0 16px 30px rgba(79, 70, 229, 0.4);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.option-action-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 40px rgba(79, 70, 229, 0.45);
+}
+
+.option-number {
+  width: 5rem;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 0.85rem;
+  padding: 0.5rem 0.6rem;
+  font-size: 0.85rem;
+  text-align: center;
+  color: #0f172a;
+  background: #ffffff;
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.08);
+}
+
+.option-number:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.18);
+}
+
+.option-divider {
+  height: 1px;
+  background: rgba(148, 163, 184, 0.35);
+  margin: 1rem 0;
+}
+
 .options-overlay--visible {
   pointer-events: auto;
 }

--- a/build_app/src/index.css
+++ b/build_app/src/index.css
@@ -14,22 +14,28 @@ html, body, #root {
   height: 100%;
 }
 body {
-  @apply bg-slate-50 text-slate-700;
+  background: linear-gradient(140deg, #e2e8f0 0%, #ffffff 45%, #e2e8f0 100%);
+  color: #334155;
   font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   margin: 0;
+  min-height: 100vh;
 }
 
 /* Layout general (centra el contenido y le da max-width) */
 .app-shell {
   max-width: var(--page-max-w);
   margin: 0 auto;
-  padding: 1rem;
+  padding: 1.5rem 1.25rem 2.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
 }
 
 /* --- Estilos específicos para el área principal --- */
 .main-grid {
   display: grid;
-  gap: 1rem;
+  gap: 1.25rem;
+  align-items: start;
 }
 
 /* para pantallas grandes usamos dos columnas: panel fijo + canvas flexible */
@@ -41,23 +47,26 @@ body {
 
 /* Panel izquierdo (tarjeta limpia) */
 .left-panel {
-  background: #ffffff;
-  border-radius: 12px;
-  box-shadow: 0 8px 24px rgba(15,23,42,0.06);
-  padding: 1rem;
+  background: linear-gradient(150deg, rgba(255,255,255,0.96) 0%, rgba(241,245,249,0.92) 100%);
+  border-radius: 18px;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.12);
+  padding: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  backdrop-filter: blur(12px);
 }
 
 /* Card que contiene el canvas (look limpio / rounded / sombra) */
 .canvas-card {
-  background: #ffffff;
-  border-radius: 14px;
-  box-shadow: 0 8px 24px rgba(15,23,42,0.06);
-  padding: 18px;
+  background: linear-gradient(160deg, rgba(255,255,255,0.95) 0%, rgba(224,231,255,0.9) 100%);
+  border-radius: 22px;
+  box-shadow: 0 22px 45px rgba(79, 70, 229, 0.12);
+  padding: 24px;
   overflow: hidden;
-  min-height: 420px;
+  min-height: 460px;
   display: flex;
   align-items: stretch;
   justify-content: center;
+  border: 1px solid rgba(79, 70, 229, 0.08);
 }
 
 /* Forzar que el canvas ocupe el 100% del ancho de la card y mantener el comportamiento de resize que hace tu script */
@@ -68,4 +77,186 @@ body {
 }
 
 /* Ajustes menores visibilidad/espaciado para la lista de secciones */
-.sections-list { gap: .5rem; display:flex; flex-direction:column; }
+.sections-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.toolbar-card {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  background: rgba(255, 255, 255, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.6);
+  border-radius: 20px;
+  padding: 0.75rem 1.25rem;
+  box-shadow: 0 22px 45px rgba(15, 23, 42, 0.16);
+  backdrop-filter: blur(14px);
+}
+
+.toolbar-divider {
+  height: 2rem;
+  width: 1px;
+  background: rgba(148, 163, 184, 0.65);
+  margin: 0 0.75rem;
+}
+
+.toolbar-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 0.75rem;
+  padding: 0.55rem 0.95rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background-color 0.18s ease;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.15);
+}
+
+.toolbar-btn:hover {
+  transform: translateY(-1px);
+}
+
+.toolbar-btn--muted {
+  background: #e2e8f0;
+  color: #475569;
+}
+
+.toolbar-btn--muted:hover {
+  background: #cbd5f5;
+}
+
+.toolbar-btn--emerald {
+  background: #34d399;
+  color: #ffffff;
+}
+
+.toolbar-btn--emerald:hover {
+  background: #10b981;
+}
+
+.toolbar-btn--rose {
+  background: #fb7185;
+  color: #ffffff;
+}
+
+.toolbar-btn--rose:hover {
+  background: #f43f5e;
+}
+
+.toolbar-btn--indigo {
+  background: #6366f1;
+  color: #ffffff;
+}
+
+.toolbar-btn--indigo:hover {
+  background: #4f46e5;
+}
+
+.toolbar-btn--sky {
+  background: #0ea5e9;
+  color: #ffffff;
+}
+
+.toolbar-btn--sky:hover {
+  background: #0284c7;
+}
+
+.toolbar-btn--amber {
+  background: #f59e0b;
+  color: #ffffff;
+}
+
+.toolbar-btn--amber:hover {
+  background: #d97706;
+}
+
+.toolbar-btn--slate {
+  background: #1e293b;
+  color: #ffffff;
+}
+
+.toolbar-btn--slate:hover {
+  background: #0f172a;
+}
+
+.toolbar-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  box-shadow: none;
+  transform: none;
+}
+
+.panel-card {
+  background: rgba(255, 255, 255, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  border-radius: 24px;
+  box-shadow: 0 30px 60px rgba(15, 23, 42, 0.16);
+  padding: 1.25rem;
+  backdrop-filter: blur(18px);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.section-card {
+  border-radius: 18px;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.1);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.section-card:hover {
+  transform: translateY(-2px);
+}
+
+.section-card--active {
+  border-color: rgba(52, 211, 153, 0.65);
+  background: rgba(236, 253, 245, 0.9);
+  box-shadow: 0 18px 36px rgba(16, 185, 129, 0.2);
+}
+
+.section-card__header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.section-card__content {
+  margin-top: 0.75rem;
+  padding-left: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.section-card__actions {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+  gap: 0.5rem;
+  align-items: center;
+  padding: 0.4rem;
+  border-radius: 0.9rem;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid rgba(226, 232, 240, 0.7);
+}
+
+.section-scroll {
+  max-height: calc(100vh - 280px);
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.footer-note {
+  text-align: center;
+  font-size: 0.75rem;
+  color: rgba(100, 116, 139, 0.75);
+  margin-top: 1.5rem;
+  margin-bottom: 2.5rem;
+}

--- a/build_app/src/index.css
+++ b/build_app/src/index.css
@@ -146,83 +146,101 @@ body {
   color: #ffffff;
 }
 
-.toolbar-menu-backdrop {
+.playback-menu {
   position: fixed;
   inset: 0;
-  z-index: 5;
-  cursor: default;
+  z-index: 60;
 }
 
-.toolbar-longpress-menu {
-  position: fixed;
-  z-index: 10;
+.playback-menu__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.28);
+  backdrop-filter: blur(2px);
+}
+
+.playback-menu__panel {
+  position: absolute;
+  transform: translateY(-50%);
+  min-width: 220px;
+  background: linear-gradient(145deg, rgba(241, 245, 249, 0.96), rgba(226, 232, 240, 0.9));
+  border-radius: 18px;
+  padding: 1rem;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.25);
+  border: 1px solid rgba(148, 163, 184, 0.35);
   display: flex;
   flex-direction: column;
-  gap: 0.45rem;
-  min-width: 9.5rem;
-  padding: 0.6rem 0.75rem;
-  border-radius: 16px;
-  background: rgba(15, 23, 42, 0.92);
-  box-shadow: 0 22px 48px rgba(15, 23, 42, 0.28);
-  transform: translateY(-50%);
+  gap: 0.75rem;
+  pointer-events: auto;
 }
 
-.toolbar-longpress-menu::before {
+.playback-menu__panel::before {
   content: "";
   position: absolute;
   top: 50%;
-  left: -7px;
-  width: 12px;
-  height: 12px;
-  background: inherit;
-  transform: translateY(-50%) rotate(45deg);
-  border-radius: 3px;
+  left: -12px;
+  transform: translateY(-50%);
+  border-width: 10px;
+  border-style: solid;
+  border-color: transparent rgba(226, 232, 240, 0.95) transparent transparent;
+  filter: drop-shadow(-2px 3px 6px rgba(15, 23, 42, 0.12));
 }
 
-.toolbar-longpress-label {
-  font-size: 0.68rem;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  color: rgba(226, 232, 240, 0.85);
+.playback-menu__panel--section {
+  background: linear-gradient(145deg, rgba(237, 233, 254, 0.96), rgba(224, 231, 255, 0.92));
 }
 
-.toolbar-menu-btn {
-  border: none;
-  border-radius: 0.6rem;
-  padding: 0.45rem 0.65rem;
-  font-size: 0.82rem;
+.playback-menu__panel--section::before {
+  border-color: transparent rgba(224, 231, 255, 0.95) transparent transparent;
+}
+
+.playback-menu__title {
+  font-size: 0.85rem;
   font-weight: 600;
-  color: #ffffff;
-  cursor: pointer;
-  transition: transform 0.16s ease, background 0.2s ease;
-  display: inline-flex;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #1f2937;
+}
+
+.playback-menu__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.playback-menu__btn {
+  display: flex;
   align-items: center;
-  gap: 0.35rem;
   justify-content: center;
+  gap: 0.45rem;
+  border-radius: 12px;
+  padding: 0.55rem 0.75rem;
+  border: none;
+  font-weight: 700;
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
 }
 
-.toolbar-menu-btn:hover {
+.playback-menu__btn:hover {
   transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.18);
 }
 
-.toolbar-menu-btn:active {
-  transform: translateY(0);
-}
-
-.toolbar-menu-btn--forward {
+.playback-menu__btn--forward {
   background: linear-gradient(135deg, #38bdf8, #2563eb);
+  color: #f8fafc;
 }
 
-.toolbar-menu-btn--forward:hover {
-  background: linear-gradient(135deg, #0ea5e9, #1d4ed8);
-}
-
-.toolbar-menu-btn--reverse {
+.playback-menu__btn--reverse {
   background: linear-gradient(135deg, #f97316, #ef4444);
+  color: #fff7ed;
 }
 
-.toolbar-menu-btn--reverse:hover {
-  background: linear-gradient(135deg, #ea580c, #dc2626);
+.playback-menu__btn:focus-visible {
+  outline: 2px solid rgba(99, 102, 241, 0.65);
+  outline-offset: 2px;
 }
 
 .toolbar-divider {

--- a/build_app/src/index.css
+++ b/build_app/src/index.css
@@ -260,3 +260,48 @@ body {
   margin-top: 1.5rem;
   margin-bottom: 2.5rem;
 }
+
+/* Drawer flotante de opciones */
+.options-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  pointer-events: none;
+}
+
+.options-overlay__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  opacity: 0;
+  transition: opacity 0.28s ease;
+}
+
+.options-drawer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: min(100%, 360px);
+  background: #ffffff;
+  box-shadow: -18px 0 35px rgba(15, 23, 42, 0.18);
+  transform: translateX(100%);
+  transition: transform 0.28s ease;
+  overflow-y: auto;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.options-overlay--visible {
+  pointer-events: auto;
+}
+
+.options-overlay--visible .options-overlay__backdrop {
+  opacity: 1;
+}
+
+.options-overlay--visible .options-drawer {
+  transform: translateX(0);
+}

--- a/build_app/src/wroplayback_planner_fix_snap_15.jsx
+++ b/build_app/src/wroplayback_planner_fix_snap_15.jsx
@@ -70,7 +70,8 @@ const OptionsPanel = ({ showOptions, setShowOptions, fieldKey, setFieldKey, bgOp
         setGrid(g => ({ ...g, cellSize: Math.max(0.1, Math.min(5, cmValue)) }));
     };
 
-    const displayCellSize = isMM ? (grid.cellSize * 10).toFixed(1) : grid.cellSize.toFixed(2);
+    const numericCellSize = isMM ? grid.cellSize * 10 : grid.cellSize;
+    const formattedCellSize = isMM ? numericCellSize.toFixed(1) : numericCellSize.toFixed(2);
 
     return (
         <div className={`options-overlay ${showOptions ? 'options-overlay--visible' : ''}`} aria-hidden={!showOptions}>
@@ -85,19 +86,268 @@ const OptionsPanel = ({ showOptions, setShowOptions, fieldKey, setFieldKey, bgOp
                 aria-modal="true"
                 onClick={(e) => e.stopPropagation()}
             >
-                <div className="flex items-center justify-between mb-2"><h3 className="text-lg font-semibold">Opciones</h3><button className="px-2 py-1 rounded bg-slate-100" onClick={() => setShowOptions(false)}>Cerrar</button></div>
-                <div className="text-sm text-slate-600 mb-2">El tapete se escala a <b>2362mm × 1143mm</b>.</div>
-                <div className="space-y-3">
-                    <div><div className="font-medium">Campo</div><select className="border rounded px-2 py-1 w-full mt-1" value={fieldKey} onChange={e => setFieldKey(e.target.value)}>{FIELD_PRESETS.map(p => <option key={p.key} value={p.key}>{p.name}</option>)}</select><label className="block mt-2 text-sm">Fondo <input type="file" accept="image/*" className="text-xs" onChange={handleBgUpload} /></label><label className="block mt-2 text-sm">Opacidad fondo: {Math.round(bgOpacity * 100)}%<input type="range" min={0} max={1} step={0.05} value={bgOpacity} onChange={e => setBgOpacity(Number(e.target.value))} className="w-full" /></label></div>
-                    <div className="border-t pt-3 space-y-2">
-                        <div className="flex justify-between items-center"><div className="font-medium">Cuadrícula</div><button onClick={() => setUnit(u => u === 'cm' ? 'mm' : 'cm')} className="px-3 py-1 rounded-lg bg-slate-200 text-sm">Usar {unit === 'cm' ? 'mm' : 'cm'}</button></div>
-                        <button onClick={() => { setIsSettingOrigin(true); setShowOptions(false); }} className="w-full px-3 py-1.5 rounded-xl bg-indigo-500 text-white text-sm inline-flex items-center justify-center"><IconTarget /> Fijar Origen en Mapa</button>
-                        <div><label className="block text-sm">Tamaño: {displayCellSize} {unit}</label><div className="flex items-center gap-2"><input type="range" min={sizeMin} max={sizeMax} step={sliderStep} className="w-full" value={displayCellSize} onChange={e => handleSizeChange(e.target.value)} /><input type="number" min={sizeMin} max={sizeMax} step={numberStep} className="w-20 border rounded px-2 py-1 text-sm" value={displayCellSize} onChange={e => handleSizeChange(e.target.value)} /></div></div>
-                        <div><label className="block text-sm">Opacidad: {Math.round(grid.lineAlpha * 100)}%</label><input type="range" min={0} max={1} step={0.05} value={grid.lineAlpha} onChange={e => setGrid(g => ({ ...g, lineAlpha: Number(e.target.value) }))} className="w-full" /></div>
-                        <div><label className="block text-sm">Offset X: {grid.offsetX}px</label><div className="flex items-center gap-2"><input type="range" min="-100" max="100" step="1" className="w-full" value={grid.offsetX} onChange={e => setGrid(g => ({ ...g, offsetX: Number(e.target.value) }))} /><input type="number" step="1" className="w-20 border rounded px-2 py-1 text-sm" value={grid.offsetX} onChange={e => setGrid(g => ({ ...g, offsetX: Number(e.target.value) }))} /></div></div>
-                        <div><label className="block text-sm">Offset Y: {grid.offsetY}px</label><div className="flex items-center gap-2"><input type="range" min="-100" max="100" step="1" className="w-full" value={grid.offsetY} onChange={e => setGrid(g => ({ ...g, offsetY: Number(e.target.value) }))} /><input type="number" step="1" className="w-20 border rounded px-2 py-1 text-sm" value={grid.offsetY} onChange={e => setGrid(g => ({ ...g, offsetY: Number(e.target.value) }))} /></div></div>
+                <div className="options-drawer__header">
+                    <div>
+                        <h3 className="options-drawer__title">Opciones</h3>
+                        <p className="options-drawer__subtitle">Configura el tapete, la cuadrícula y el robot para organizar mejor tu planificación.</p>
                     </div>
-                    <div className="border-t pt-3"><div className="font-medium">Robot</div><div className="grid grid-cols-2 gap-2"><label className="text-sm">Ancho (cm)<input type="number" className="w-full border rounded px-2 py-1" value={robot.width} onChange={e => setRobot(r => ({ ...r, width: Number(e.target.value) || 0 }))} /></label><label className="text-sm">Largo (cm)<input type="number" className="w-full border rounded px-2 py-1" value={robot.length} onChange={e => setRobot(r => ({ ...r, length: Number(e.target.value) || 0 }))} /></label><label className="text-sm">Color<input type="color" className="w-full h-8 border-0" value={robot.color} onChange={e => setRobot(r => ({ ...r, color: e.target.value }))} /></label><label className="text-sm">Imagen<input type="file" accept="image/*" className="text-xs" onChange={handleRobotImageUpload} /></label><label className="col-span-2 text-sm">Opacidad: {Math.round((robot.opacity ?? 1) * 100)}%<input type="range" min={0.1} max={1} step={0.05} value={robot.opacity ?? 1} onChange={e => setRobot(r => ({ ...r, opacity: Number(e.target.value) }))} className="w-full" /></label></div><div className="grid grid-cols-3 gap-2 mt-2 text-sm"><label>X (px)<input type="number" className="w-full border rounded px-2 py-1" value={Math.round(initialPose.x)} onChange={e => setInitialPose(p => ({ ...p, x: Number(e.target.value) }))} /></label><label>Y (px)<input type="number" className="w-full border rounded px-2 py-1" value={Math.round(initialPose.y)} onChange={e => setInitialPose(p => ({ ...p, y: Number(e.target.value) }))} /></label><label>Ángulo (°)<input type="number" className="w-full border rounded px-2 py-1" value={Math.round(initialPose.theta * RAD2DEG)} onChange={e => setInitialPose(p => ({ ...p, theta: Number(e.target.value) * DEG2RAD }))} /></label></div></div>
+                    <button className="options-close-btn" onClick={() => setShowOptions(false)}>Cerrar</button>
+                </div>
+                <div className="options-drawer__intro">El tapete se escala automáticamente a <b>2362mm × 1143mm</b>. Ajusta los controles para que coincida con tu entorno.</div>
+                <div className="options-drawer__content">
+                    <section className="option-section">
+                        <header className="option-section__header">
+                            <h4 className="option-section__title">Tapete</h4>
+                            <p className="option-section__subtitle">Elige un tapete predefinido o sube una imagen personalizada.</p>
+                        </header>
+                        <div className="option-card">
+                            <div className="option-card__grid option-card__grid--auto">
+                                <label className="option-field">
+                                    <span className="option-field__label">Tapete base</span>
+                                    <select className="option-field__control" value={fieldKey} onChange={e => setFieldKey(e.target.value)}>
+                                        {FIELD_PRESETS.map(p => (
+                                            <option key={p.key} value={p.key}>{p.name}</option>
+                                        ))}
+                                    </select>
+                                </label>
+                                <label className="option-field option-field--file">
+                                    <span className="option-field__label">Fondo personalizado</span>
+                                    <span className="option-upload">
+                                        <input type="file" accept="image/*" onChange={handleBgUpload} />
+                                        <span className="option-upload__text">Subir imagen</span>
+                                    </span>
+                                    <span className="option-field__hint">Ideal para mapas escaneados o fotografías de tu tapete.</span>
+                                </label>
+                                <div className="option-field option-field--range">
+                                    <div className="option-field__label">Opacidad del fondo</div>
+                                    <div className="option-field__controls">
+                                        <input type="range" min={0} max={1} step={0.05} value={bgOpacity} onChange={e => setBgOpacity(Number(e.target.value))} />
+                                        <span className="option-field__value">{Math.round(bgOpacity * 100)}%</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section className="option-section">
+                        <header className="option-section__header">
+                            <h4 className="option-section__title">Cuadrícula y unidades</h4>
+                            <p className="option-section__subtitle">Controla la densidad de la cuadrícula y alinea el origen con tu referencia física.</p>
+                        </header>
+                        <div className="option-card">
+                            <div className="option-card__grid option-card__grid--two">
+                                <div className="option-field">
+                                    <span className="option-field__label">Unidad de trabajo</span>
+                                    <div className="option-field__controls option-field__controls--single">
+                                        <button
+                                            type="button"
+                                            className="option-chip-button"
+                                            onClick={() => setUnit(u => u === 'cm' ? 'mm' : 'cm')}
+                                        >
+                                            Mostrar en {unit === 'cm' ? 'milímetros' : 'centímetros'}
+                                        </button>
+                                    </div>
+                                    <span className="option-field__hint">Actualmente estás introduciendo valores en {unit === 'cm' ? 'centímetros' : 'milímetros'}.</span>
+                                </div>
+                                <div className="option-field">
+                                    <span className="option-field__label">Origen de coordenadas</span>
+                                    <div className="option-field__controls option-field__controls--single">
+                                        <button
+                                            type="button"
+                                            className="option-action-button"
+                                            onClick={() => { setIsSettingOrigin(true); setShowOptions(false); }}
+                                        >
+                                            <IconTarget /> Fijar en el mapa
+                                        </button>
+                                    </div>
+                                    <span className="option-field__hint">Pulsa sobre el tapete para definir dónde se ubica (0, 0).</span>
+                                </div>
+                            </div>
+                            <div className="option-divider" />
+                            <div className="option-field option-field--range">
+                                <div className="option-field__label">Tamaño de celda</div>
+                                <span className="option-field__hint">Cada cuadrícula representa {formattedCellSize} {unit}.</span>
+                                <div className="option-field__controls">
+                                    <input
+                                        type="range"
+                                        min={sizeMin}
+                                        max={sizeMax}
+                                        step={sliderStep}
+                                        value={numericCellSize}
+                                        onChange={e => handleSizeChange(e.target.value)}
+                                    />
+                                    <input
+                                        type="number"
+                                        min={sizeMin}
+                                        max={sizeMax}
+                                        step={numberStep}
+                                        className="option-number"
+                                        value={Number(numericCellSize.toFixed(isMM ? 1 : 2))}
+                                        onChange={e => handleSizeChange(e.target.value)}
+                                    />
+                                    <span className="option-field__value">{unit}</span>
+                                </div>
+                            </div>
+                            <div className="option-field option-field--range">
+                                <div className="option-field__label">Opacidad de líneas</div>
+                                <div className="option-field__controls">
+                                    <input
+                                        type="range"
+                                        min={0}
+                                        max={1}
+                                        step={0.05}
+                                        value={grid.lineAlpha}
+                                        onChange={e => setGrid(g => ({ ...g, lineAlpha: Number(e.target.value) }))}
+                                    />
+                                    <span className="option-field__value">{Math.round(grid.lineAlpha * 100)}%</span>
+                                </div>
+                            </div>
+                            <div className="option-card__grid option-card__grid--two">
+                                <div className="option-field option-field--range">
+                                    <div className="option-field__label">Offset X</div>
+                                    <span className="option-field__hint">Desplaza la cuadrícula horizontalmente.</span>
+                                    <div className="option-field__controls">
+                                        <input
+                                            type="range"
+                                            min="-100"
+                                            max="100"
+                                            step="1"
+                                            value={grid.offsetX}
+                                            onChange={e => setGrid(g => ({ ...g, offsetX: Number(e.target.value) }))}
+                                        />
+                                        <input
+                                            type="number"
+                                            step="1"
+                                            className="option-number"
+                                            value={grid.offsetX}
+                                            onChange={e => setGrid(g => ({ ...g, offsetX: Number(e.target.value) }))}
+                                        />
+                                        <span className="option-field__value">px</span>
+                                    </div>
+                                </div>
+                                <div className="option-field option-field--range">
+                                    <div className="option-field__label">Offset Y</div>
+                                    <span className="option-field__hint">Desplaza la cuadrícula verticalmente.</span>
+                                    <div className="option-field__controls">
+                                        <input
+                                            type="range"
+                                            min="-100"
+                                            max="100"
+                                            step="1"
+                                            value={grid.offsetY}
+                                            onChange={e => setGrid(g => ({ ...g, offsetY: Number(e.target.value) }))}
+                                        />
+                                        <input
+                                            type="number"
+                                            step="1"
+                                            className="option-number"
+                                            value={grid.offsetY}
+                                            onChange={e => setGrid(g => ({ ...g, offsetY: Number(e.target.value) }))}
+                                        />
+                                        <span className="option-field__value">px</span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section className="option-section">
+                        <header className="option-section__header">
+                            <h4 className="option-section__title">Robot</h4>
+                            <p className="option-section__subtitle">Define las dimensiones y apariencia del robot en pantalla.</p>
+                        </header>
+                        <div className="option-card">
+                            <div className="option-card__grid option-card__grid--two">
+                                <label className="option-field">
+                                    <span className="option-field__label">Ancho (cm)</span>
+                                    <input
+                                        type="number"
+                                        className="option-field__control"
+                                        value={robot.width}
+                                        onChange={e => setRobot(r => ({ ...r, width: Number(e.target.value) || 0 }))}
+                                    />
+                                </label>
+                                <label className="option-field">
+                                    <span className="option-field__label">Largo (cm)</span>
+                                    <input
+                                        type="number"
+                                        className="option-field__control"
+                                        value={robot.length}
+                                        onChange={e => setRobot(r => ({ ...r, length: Number(e.target.value) || 0 }))}
+                                    />
+                                </label>
+                                <label className="option-field">
+                                    <span className="option-field__label">Color</span>
+                                    <input
+                                        type="color"
+                                        className="option-field__control option-field__control--color"
+                                        value={robot.color}
+                                        onChange={e => setRobot(r => ({ ...r, color: e.target.value }))}
+                                    />
+                                </label>
+                                <label className="option-field option-field--file">
+                                    <span className="option-field__label">Imagen del robot</span>
+                                    <span className="option-upload">
+                                        <input type="file" accept="image/*" onChange={handleRobotImageUpload} />
+                                        <span className="option-upload__text">Seleccionar archivo</span>
+                                    </span>
+                                    <span className="option-field__hint">Utiliza PNG con fondo transparente para mejores resultados.</span>
+                                </label>
+                            </div>
+                            <div className="option-field option-field--range">
+                                <div className="option-field__label">Opacidad del robot</div>
+                                <div className="option-field__controls">
+                                    <input
+                                        type="range"
+                                        min={0.1}
+                                        max={1}
+                                        step={0.05}
+                                        value={robot.opacity ?? 1}
+                                        onChange={e => setRobot(r => ({ ...r, opacity: Number(e.target.value) }))}
+                                    />
+                                    <span className="option-field__value">{Math.round((robot.opacity ?? 1) * 100)}%</span>
+                                </div>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section className="option-section">
+                        <header className="option-section__header">
+                            <h4 className="option-section__title">Posición inicial</h4>
+                            <p className="option-section__subtitle">Ajusta la ubicación inicial del robot en el plano.</p>
+                        </header>
+                        <div className="option-card">
+                            <div className="option-card__grid option-card__grid--three">
+                                <label className="option-field">
+                                    <span className="option-field__label">Posición X (px)</span>
+                                    <input
+                                        type="number"
+                                        className="option-field__control"
+                                        value={Math.round(initialPose.x)}
+                                        onChange={e => setInitialPose(p => ({ ...p, x: Number(e.target.value) }))}
+                                    />
+                                </label>
+                                <label className="option-field">
+                                    <span className="option-field__label">Posición Y (px)</span>
+                                    <input
+                                        type="number"
+                                        className="option-field__control"
+                                        value={Math.round(initialPose.y)}
+                                        onChange={e => setInitialPose(p => ({ ...p, y: Number(e.target.value) }))}
+                                    />
+                                </label>
+                                <label className="option-field">
+                                    <span className="option-field__label">Ángulo (°)</span>
+                                    <input
+                                        type="number"
+                                        className="option-field__control"
+                                        value={Math.round(initialPose.theta * RAD2DEG)}
+                                        onChange={e => setInitialPose(p => ({ ...p, theta: Number(e.target.value) * DEG2RAD }))}
+                                    />
+                                </label>
+                            </div>
+                        </div>
+                    </section>
                 </div>
             </div>
         </div>

--- a/build_app/src/wroplayback_planner_fix_snap_15.jsx
+++ b/build_app/src/wroplayback_planner_fix_snap_15.jsx
@@ -46,6 +46,24 @@ const OptionsPanel = ({ showOptions, setShowOptions, fieldKey, setFieldKey, bgOp
     const sliderStep = isMM ? 1 : 0.1;
     const numberStep = isMM ? 0.1 : 0.01;
 
+    useEffect(() => {
+        if (!showOptions) return undefined;
+        const previousOverflow = document.body.style.overflow;
+        const handleKeyDown = (event) => {
+            if (event.key === 'Escape') {
+                setShowOptions(false);
+            }
+        };
+
+        document.body.style.overflow = 'hidden';
+        window.addEventListener('keydown', handleKeyDown);
+
+        return () => {
+            document.body.style.overflow = previousOverflow;
+            window.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [showOptions, setShowOptions]);
+
     const handleSizeChange = (valueStr) => {
         const value = parseFloat(valueStr) || 0;
         const cmValue = isMM ? value / 10 : value;
@@ -55,18 +73,17 @@ const OptionsPanel = ({ showOptions, setShowOptions, fieldKey, setFieldKey, bgOp
     const displayCellSize = isMM ? (grid.cellSize * 10).toFixed(1) : grid.cellSize.toFixed(2);
 
     return (
-        <div className={`fixed inset-0 z-50 ${showOptions ? '' : 'pointer-events-none'}`}>
+        <div className={`options-overlay ${showOptions ? 'options-overlay--visible' : ''}`} aria-hidden={!showOptions}>
             <div
-                className={`absolute inset-0 bg-black/40 transition-opacity ${showOptions ? 'opacity-100' : 'opacity-0'}`}
-                onMouseDown={() => setShowOptions(false)}
-                onTouchStart={() => setShowOptions(false)}
+                className="options-overlay__backdrop"
+                onClick={() => setShowOptions(false)}
+                role="presentation"
             />
             <div
-                className={`absolute right-0 top-0 h-full w-full max-w-sm bg-white shadow-2xl p-4 overflow-y-auto transition-transform ${showOptions ? 'translate-x-0' : 'translate-x-full'}`}
+                className="options-drawer"
                 role="dialog"
                 aria-modal="true"
-                onMouseDown={(e) => e.stopPropagation()}
-                onTouchStart={(e) => e.stopPropagation()}
+                onClick={(e) => e.stopPropagation()}
             >
                 <div className="flex items-center justify-between mb-2"><h3 className="text-lg font-semibold">Opciones</h3><button className="px-2 py-1 rounded bg-slate-100" onClick={() => setShowOptions(false)}>Cerrar</button></div>
                 <div className="text-sm text-slate-600 mb-2">El tapete se escala a <b>2362mm × 1143mm</b>.</div>

--- a/build_app/src/wroplayback_planner_fix_snap_15.jsx
+++ b/build_app/src/wroplayback_planner_fix_snap_15.jsx
@@ -83,35 +83,89 @@ const SectionsPanel = ({ sections, setSections, selectedSectionId, setSelectedSe
     const handleActionDragStart = (e, sectionId, actionIndex) => { setDraggedAction({ sectionId, actionIndex }); e.dataTransfer.effectAllowed = 'move'; e.dataTransfer.setData('text/plain', ''); };
     const handleActionDrop = (e, targetSectionId, targetActionIndex) => { e.preventDefault(); if (!draggedAction || draggedAction.sectionId !== targetSectionId) return; const { actionIndex: draggedIndex } = draggedAction; if (draggedIndex === targetActionIndex) return; const section = sections.find(s => s.id === targetSectionId); if (!section) return; const reorderedActions = [...section.actions]; const [draggedItem] = reorderedActions.splice(draggedIndex, 1); reorderedActions.splice(targetActionIndex, 0, draggedItem); updateSectionActions(targetSectionId, reorderedActions); };
 
-    if (isCollapsed) return (<div className="bg-white rounded-2xl shadow p-3 self-start"><button onClick={() => setIsCollapsed(false)} className="p-2 rounded-lg hover:bg-slate-100" title="Expandir Panel"><IconChevronRight /></button></div>);
+    if (isCollapsed) {
+        return (
+            <div className="panel-card self-start flex items-center justify-center w-16 h-16">
+                <button
+                    onClick={() => setIsCollapsed(false)}
+                    className="toolbar-btn toolbar-btn--muted"
+                    title="Expandir Panel"
+                >
+                    <IconChevronRight />
+                </button>
+            </div>
+        );
+    }
 
     return (
-        <div className="bg-white rounded-2xl shadow p-3 space-y-2 self-start">
-            <div className="flex items-center justify-between"><h2 className="text-lg font-medium">Secciones</h2><div><button onClick={addSection} className="px-3 py-1.5 rounded-xl bg-emerald-500 text-white text-sm mr-2">+ Añadir</button><button onClick={() => setIsCollapsed(true)} className="p-2 rounded-lg hover:bg-slate-100 inline-flex align-middle" title="Minimizar Panel"><IconChevronLeft /></button></div></div>
-            <div className="space-y-2 max-h-[calc(100vh-250px)] overflow-auto pr-1">
+        <div className="panel-card self-start">
+            <div className="flex items-center justify-between gap-2">
+                <h2 className="text-xl font-semibold text-slate-700">Secciones</h2>
+                <div className="flex items-center gap-2">
+                    <button onClick={addSection} className="toolbar-btn toolbar-btn--emerald text-sm">+ Añadir</button>
+                    <button onClick={() => setIsCollapsed(true)} className="toolbar-btn toolbar-btn--muted" title="Minimizar Panel">
+                        <IconChevronLeft />
+                    </button>
+                </div>
+            </div>
+            <div className="section-scroll space-y-3">
                 {sections.map(s => {
                     const isExpanded = expandedSections.includes(s.id);
                     return (
-                        <div key={s.id} className={`p-2 rounded-xl border ${selectedSectionId === s.id ? 'border-emerald-500 bg-emerald-50' : 'border-slate-200'}`} onClick={() => setSelectedSectionId(s.id)}>
-                            <div className="flex items-center gap-2">
-                                <button onClick={(e) => { e.stopPropagation(); toggleSectionExpansion(s.id); }} className="p-1">{isExpanded ? <IconChevronDown /> : <IconChevronRight />}</button>
-                                <input className="flex-1 border rounded-lg px-2 py-1 text-sm" value={s.name} onChange={e => setSections(prev => prev.map(x => x.id === s.id ? { ...x, name: e.target.value } : x))} onClick={e => e.stopPropagation()} />
-                                <input type="color" className="w-8 h-8" value={s.color || '#0ea5e9'} onChange={e => setSections(prev => prev.map(x => x.id === s.id ? { ...x, color: e.target.value } : x))} onClick={e => e.stopPropagation()} />
-                                <button onClick={(e) => { e.stopPropagation(); toggleSectionVisibility(s.id); }} className={`p-1 rounded-md ${s.isVisible ? 'text-slate-600' : 'text-slate-300'}`}>{s.isVisible ? <IconEye /> : <IconEyeOff />}</button>
+                        <div
+                            key={s.id}
+                            className={`section-card ${selectedSectionId === s.id ? 'section-card--active' : ''}`}
+                            onClick={() => setSelectedSectionId(s.id)}
+                        >
+                            <div className="section-card__header px-3 py-2">
+                                <button
+                                    onClick={(e) => { e.stopPropagation(); toggleSectionExpansion(s.id); }}
+                                    className="toolbar-btn toolbar-btn--muted px-2 py-1"
+                                >
+                                    {isExpanded ? <IconChevronDown /> : <IconChevronRight />}
+                                </button>
+                                <input
+                                    className="flex-1 border border-slate-200/70 rounded-lg px-3 py-1 text-sm bg-white/80"
+                                    value={s.name}
+                                    onChange={e => setSections(prev => prev.map(x => x.id === s.id ? { ...x, name: e.target.value } : x))}
+                                    onClick={e => e.stopPropagation()}
+                                />
+                                <input
+                                    type="color"
+                                    className="w-9 h-9 rounded-lg border border-slate-200/50"
+                                    value={s.color || '#0ea5e9'}
+                                    onChange={e => setSections(prev => prev.map(x => x.id === s.id ? { ...x, color: e.target.value } : x))}
+                                    onClick={e => e.stopPropagation()}
+                                />
+                                <button
+                                    onClick={(e) => { e.stopPropagation(); toggleSectionVisibility(s.id); }}
+                                    className={`toolbar-btn px-2 py-1 ${s.isVisible ? 'toolbar-btn--muted' : 'toolbar-btn--muted opacity-40'}`}
+                                >
+                                    {s.isVisible ? <IconEye /> : <IconEyeOff />}
+                                </button>
                             </div>
                             {isExpanded && (
-                                <div className="mt-2 pl-2 space-y-1" onDrop={() => setDraggedAction(null)} onDragEnd={() => setDraggedAction(null)}>
-                                    <div className="text-xs text-slate-500 mt-1">Inicio: {(() => { const start = computePoseUpToSection(s.id); return `${pxToUnit(start.x).toFixed(1)}cm, ${pxToUnit(start.y).toFixed(1)}cm, ${Math.round(start.theta * RAD2DEG)}°`; })()}</div>
-                                    <div className="text-xs text-slate-600 pt-2">Acciones:</div>
+                                <div className="section-card__content" onDrop={() => setDraggedAction(null)} onDragEnd={() => setDraggedAction(null)}>
+                                    <div className="text-xs text-slate-500">Inicio: {(() => { const start = computePoseUpToSection(s.id); return `${pxToUnit(start.x).toFixed(1)}cm, ${pxToUnit(start.y).toFixed(1)}cm, ${Math.round(start.theta * RAD2DEG)}°`; })()}</div>
+                                    <div className="text-xs text-slate-600 font-semibold">Acciones:</div>
                                     {s.actions.length === 0 ? (<div className="text-xs text-slate-500">Sin acciones. Dibuja para crear.</div>) : (
                                         s.actions.map((a, i) => {
                                             const isDragging = draggedAction?.sectionId === s.id && draggedAction?.actionIndex === i;
-                                            return (<div key={i} draggable onDragStart={(e) => handleActionDragStart(e, s.id, i)} onDrop={(e) => handleActionDrop(e, s.id, i)} onDragOver={(e) => e.preventDefault()} className={`grid grid-cols-[auto_auto_1fr_auto] gap-2 items-center p-1.5 border rounded-xl ${isDragging ? 'opacity-50 bg-slate-200' : 'bg-white'}`}><span className="cursor-move touch-none p-1"><IconGripVertical /></span><span className="text-xs font-medium">{a.type === 'move' ? 'Avanzar' : 'Girar'}</span>
+                                            return (
+                                                <div
+                                                    key={i}
+                                                    draggable
+                                                    onDragStart={(e) => handleActionDragStart(e, s.id, i)}
+                                                    onDrop={(e) => handleActionDrop(e, s.id, i)}
+                                                    onDragOver={(e) => e.preventDefault()}
+                                                    className={`section-card__actions ${isDragging ? 'opacity-60 border-dashed border-indigo-300' : 'border-slate-200/70'}`}
+                                                >
+                                                    <span className="cursor-move touch-none p-1 text-slate-400"><IconGripVertical /></span><span className="text-xs font-medium text-slate-600">{a.type === 'move' ? 'Avanzar' : 'Girar'}</span>
                                                 {a.type === 'move' ?
                                                     (<label className="text-xs flex items-center gap-2">Dist ({unit})<input
                                                         type="number"
                                                         step={unit === 'mm' ? 0.1 : 0.01}
-                                                        className="w-full border rounded-lg px-2 py-1"
+                                                        className="w-full border border-slate-200/80 rounded-lg px-2 py-1 text-slate-700 bg-white/80"
                                                         value={unit === 'mm' ? (a.distance * 10).toFixed(1) : a.distance.toFixed(2)}
                                                         onChange={e => {
                                                             const val = parseFloat(e.target.value) || 0;
@@ -123,7 +177,7 @@ const SectionsPanel = ({ sections, setSections, selectedSectionId, setSelectedSe
                                                     (<label className="text-xs flex items-center gap-2">Ángulo (°)<input
                                                         type="number"
                                                         step="1"
-                                                        className="w-full border rounded-lg px-2 py-1"
+                                                        className="w-full border border-slate-200/80 rounded-lg px-2 py-1 text-slate-700 bg-white/80"
                                                         value={a.angle}
                                                         onChange={e => {
                                                             const newActions = s.actions.map((act, idx) => (i === idx ? { ...act, angle: parseFloat(e.target.value) || 0 } : act));
@@ -131,7 +185,14 @@ const SectionsPanel = ({ sections, setSections, selectedSectionId, setSelectedSe
                                                         }}
                                                     /></label>)
                                                 }
-                                            <button onClick={() => { const newActions = s.actions.filter((_, idx) => idx !== i); updateSectionActions(s.id, newActions); }} className="px-2 py-1 text-[11px] rounded-lg bg-rose-100 text-rose-700">X</button></div>);
+                                            <button
+                                                onClick={() => { const newActions = s.actions.filter((_, idx) => idx !== i); updateSectionActions(s.id, newActions); }}
+                                                className="toolbar-btn toolbar-btn--rose px-2 py-1 text-[11px]"
+                                            >
+                                                Quitar
+                                            </button>
+                                                </div>
+                                            );
                                         })
                                     )}
                                 </div>
@@ -140,7 +201,13 @@ const SectionsPanel = ({ sections, setSections, selectedSectionId, setSelectedSe
                     );
                 })}
             </div>
-            <div className="pt-2 flex gap-2"><button onClick={exportMission} className="px-3 py-1.5 rounded-xl bg-amber-500 text-white text-sm shadow">Guardar (.json)</button><label className="px-3 py-1.5 rounded-xl bg-slate-200 text-slate-900 text-sm shadow cursor-pointer">Cargar <input type="file" accept="application/json" className="hidden" onChange={importMission} /></label></div>
+            <div className="pt-2 flex flex-wrap gap-2">
+                <button onClick={exportMission} className="toolbar-btn toolbar-btn--amber text-sm">Guardar (.json)</button>
+                <label className="toolbar-btn toolbar-btn--muted text-sm cursor-pointer">
+                    Cargar
+                    <input type="file" accept="application/json" className="hidden" onChange={importMission} />
+                </label>
+            </div>
         </div>
     );
 };
@@ -159,22 +226,22 @@ const Toolbar = ({ drawMode, setDrawMode, snapAngles, setSnapAngles, snapGrid, s
     };
 
     return (
-        <div className="flex flex-wrap items-center gap-2 p-3 bg-white shadow sticky top-0 z-10">
-            <button onClick={() => setDrawMode(d => !d)} className={`px-3 py-1 rounded-xl w-24 ${drawMode ? 'bg-emerald-500 text-white' : 'bg-slate-200'}`}>
+        <div className="toolbar-card sticky top-4 z-20">
+            <button onClick={() => setDrawMode(d => !d)} className={`toolbar-btn w-28 ${drawMode ? 'toolbar-btn--emerald' : 'toolbar-btn--muted'}`}>
                 {drawMode ? 'Dibujando' : 'Editando'}
             </button>
-            <button onClick={handleRulerToggle} className={`px-3 py-1 rounded-xl inline-flex items-center ${rulerActive ? 'bg-rose-500 text-white' : 'bg-slate-200'}`}>
+            <button onClick={handleRulerToggle} className={`toolbar-btn ${rulerActive ? 'toolbar-btn--rose' : 'toolbar-btn--muted'}`}>
                 <IconRuler /> Regla
             </button>
-            <button onClick={handleSnapAnglesToggle} className={`px-3 py-1 rounded-xl ${snapAngles ? 'bg-indigo-500 text-white' : 'bg-slate-200'}`}>Snap 15°</button>
-            <button onClick={handleSnapGridToggle} className={`px-3 py-1 rounded-xl ${snapGrid ? 'bg-indigo-500 text-white' : 'bg-slate-200'}`}>Snap Grid</button>
-            <div className="mx-2 w-px h-6 bg-slate-200" />
-            <button onClick={startMission} className="px-3 py-1 rounded-xl bg-blue-600 text-white">Misión</button>
-            <button onClick={startSection} className="px-3 py-1 rounded-xl bg-blue-500 text-white">Sección</button>
-            <button onClick={pauseResume} disabled={!isRunning} className={`px-3 py-1 rounded-xl ${isPaused ? 'bg-amber-500' : 'bg-amber-400'} text-white ${!isRunning ? 'opacity-50 cursor-not-allowed' : ''}`}>{isPaused ? 'Reanudar' : 'Pausar'}</button>
-            <button onClick={stopPlayback} disabled={!isRunning} className={`px-3 py-1 rounded-xl bg-rose-500 text-white ${!isRunning ? 'opacity-50 cursor-not-allowed' : ''}`}>Detener</button>
+            <button onClick={handleSnapAnglesToggle} className={`toolbar-btn ${snapAngles ? 'toolbar-btn--indigo' : 'toolbar-btn--muted'}`}>Snap 15°</button>
+            <button onClick={handleSnapGridToggle} className={`toolbar-btn ${snapGrid ? 'toolbar-btn--indigo' : 'toolbar-btn--muted'}`}>Snap Grid</button>
+            <div className="toolbar-divider" />
+            <button onClick={startMission} className="toolbar-btn toolbar-btn--sky">Misión</button>
+            <button onClick={startSection} className="toolbar-btn toolbar-btn--indigo">Sección</button>
+            <button onClick={pauseResume} disabled={!isRunning} className={`toolbar-btn ${isPaused ? 'toolbar-btn--emerald' : 'toolbar-btn--amber'}`}>{isPaused ? 'Reanudar' : 'Pausar'}</button>
+            <button onClick={stopPlayback} disabled={!isRunning} className="toolbar-btn toolbar-btn--rose">Detener</button>
             <div className="ml-auto flex items-center gap-2 text-sm">
-                <button onClick={() => setShowOptions(true)} className="px-3 py-1 rounded-xl bg-slate-800 text-white">Opciones</button>
+                <button onClick={() => setShowOptions(true)} className="toolbar-btn toolbar-btn--slate">Opciones</button>
             </div>
         </div>
     );
@@ -505,41 +572,39 @@ export default function WROPlaybackPlanner() {
     const importMission = (e) => { const f = e.target.files?.[0]; if (!f) return; const r = new FileReader(); r.onload = () => { try { const data = JSON.parse(r.result); if (Array.isArray(data.sections)) setSections(data.sections.map(s => ({...s, isVisible: s.isVisible !== false}))); if (data.initialPose) setInitialPose(data.initialPose); if (data.robot) setRobot(prev => ({ ...prev, ...data.robot })); if (data.grid) setGrid(prev => ({ ...prev, ...data.grid })); if (data.fieldKey) setFieldKey(data.fieldKey); if (typeof data.bgOpacity === 'number') setBgOpacity(data.bgOpacity); } catch (err) { console.error('Invalid mission file', err); alert('No se pudo importar: archivo inválido'); } }; r.readAsText(f); };
     
     return (
-        <div className="w-full h-full min-h-screen bg-slate-50">
-            <Toolbar {...{ drawMode, setDrawMode, snapAngles, setSnapAngles, snapGrid, setSnapGrid, isRunning, isPaused, startMission, startSection, pauseResume, stopPlayback, setShowOptions, rulerActive, handleRulerToggle }} />
-
+        <div className="w-full h-full min-h-screen">
             <main className="app-shell">
-            <div className="main-grid">
-                {/* PANEL IZQUIERDO (card) */}
-                <aside className="left-panel">
-                {/* mantén la misma instancia del SectionsPanel, pero agrégale un wrapper para spacing */}
-                <div className="sections-list">
-                    <SectionsPanel {...{ sections, setSections, selectedSectionId, setSelectedSectionId, addSection, exportMission, importMission, updateSectionActions, computePoseUpToSection, pxToUnit, isCollapsed: isSectionsPanelCollapsed, setIsCollapsed: setIsSectionsPanelCollapsed, expandedSections, toggleSectionExpansion, toggleSectionVisibility, unit }} />
-                </div>
-                </aside>
+                <Toolbar {...{ drawMode, setDrawMode, snapAngles, setSnapAngles, snapGrid, setSnapGrid, isRunning, isPaused, startMission, startSection, pauseResume, stopPlayback, setShowOptions, rulerActive, handleRulerToggle }} />
 
-                {/* AREA DEL CANVAS (card limpia) */}
-                <section className="canvas-card" aria-label="Canvas">
-                <div ref={containerRef} style={{ width: '100%' }}>
-                    <canvas ref={canvasRef}
-                            onMouseMove={onCanvasMove}
-                            onMouseDown={onCanvasDown}
-                            onMouseUp={onCanvasUp}
-                            onMouseLeave={onCanvasUp}
-                            onClick={onCanvasClick}
-                            onContextMenu={handleContextMenu}
-                            className={`${isSettingOrigin ? 'cursor-copy' : 'cursor-crosshair'}`}
+                <div className="main-grid">
+                    {/* PANEL IZQUIERDO (card) */}
+                    <aside className="left-panel">
+                        <div className="sections-list">
+                            <SectionsPanel {...{ sections, setSections, selectedSectionId, setSelectedSectionId, addSection, exportMission, importMission, updateSectionActions, computePoseUpToSection, pxToUnit, isCollapsed: isSectionsPanelCollapsed, setIsCollapsed: setIsSectionsPanelCollapsed, expandedSections, toggleSectionExpansion, toggleSectionVisibility, unit }} />
+                        </div>
+                    </aside>
+
+                    {/* AREA DEL CANVAS (card limpia) */}
+                    <section className="canvas-card" aria-label="Canvas">
+                        <div ref={containerRef} style={{ width: '100%' }}>
+                            <canvas
+                                ref={canvasRef}
+                                onMouseMove={onCanvasMove}
+                                onMouseDown={onCanvasDown}
+                                onMouseUp={onCanvasUp}
+                                onMouseLeave={onCanvasUp}
+                                onClick={onCanvasClick}
+                                onContextMenu={handleContextMenu}
+                                className={`${isSettingOrigin ? 'cursor-copy' : 'cursor-crosshair'}`}
                             />
+                        </div>
+                    </section>
                 </div>
-                </section>
-            </div>
             </main>
-
-
 
             <OptionsPanel {...{ showOptions, setShowOptions, fieldKey, setFieldKey, bgOpacity, setBgOpacity, grid, setGrid, robot, setRobot, initialPose, setInitialPose, handleBgUpload, handleRobotImageUpload, setIsSettingOrigin, unit, setUnit }} />
 
-            <footer className="max-w-7xl mx-auto px-4 pb-8 pt-2 text-xs text-slate-500 text-center">Dimensiones del tapete: 2362mm × 1143mm.</footer>
+            <footer className="footer-note">Dimensiones del tapete: 2362mm × 1143mm.</footer>
         </div>
     );
 }

--- a/build_app/src/wroplayback_planner_fix_snap_15.jsx
+++ b/build_app/src/wroplayback_planner_fix_snap_15.jsx
@@ -56,8 +56,18 @@ const OptionsPanel = ({ showOptions, setShowOptions, fieldKey, setFieldKey, bgOp
 
     return (
         <div className={`fixed inset-0 z-50 ${showOptions ? '' : 'pointer-events-none'}`}>
-            <div className={`absolute inset-0 bg-black/40 transition-opacity ${showOptions ? 'opacity-100' : 'opacity-0'}`} onClick={() => setShowOptions(false)} />
-            <div className={`absolute right-0 top-0 h-full w-full max-w-sm bg-white shadow-2xl p-4 overflow-y-auto transition-transform ${showOptions ? 'translate-x-0' : 'translate-x-full'}`}>
+            <div
+                className={`absolute inset-0 bg-black/40 transition-opacity ${showOptions ? 'opacity-100' : 'opacity-0'}`}
+                onMouseDown={() => setShowOptions(false)}
+                onTouchStart={() => setShowOptions(false)}
+            />
+            <div
+                className={`absolute right-0 top-0 h-full w-full max-w-sm bg-white shadow-2xl p-4 overflow-y-auto transition-transform ${showOptions ? 'translate-x-0' : 'translate-x-full'}`}
+                role="dialog"
+                aria-modal="true"
+                onMouseDown={(e) => e.stopPropagation()}
+                onTouchStart={(e) => e.stopPropagation()}
+            >
                 <div className="flex items-center justify-between mb-2"><h3 className="text-lg font-semibold">Opciones</h3><button className="px-2 py-1 rounded bg-slate-100" onClick={() => setShowOptions(false)}>Cerrar</button></div>
                 <div className="text-sm text-slate-600 mb-2">El tapete se escala a <b>2362mm × 1143mm</b>.</div>
                 <div className="space-y-3">


### PR DESCRIPTION
## Summary
- redesign the planner shell with gradients, card-like panels, and updated spacing so the sections stay on the left and the canvas on the right
- restyle the sections panel, toolbar, and action controls with colorful buttons, hover states, and polished cards that match the desired mockup

## Testing
- npm run lint
